### PR TITLE
Add readme instruction to create `.asdfrc` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ wget https://github.com/danhper/asdf-exec/releases/download/v0.1/asdf-exec-linux
 wget https://github.com/danhper/asdf-exec/releases/download/v0.1/asdf-exec-darwin-x64 -O ~/.asdf/bin/private/asdf-exec
 ```
 
+Then, create an `.asdfrc` file if you don't have one already:
+```
+touch ~/.asdfrc
+```
+
 Then, patch asdf reshim command code and regenerate all shims.
 
 ```


### PR DESCRIPTION
NOTE: I think you probably don't want to actually merge this, you probably want to just update the code to gracefully handle the absence of an `.asdfrc` file.  But in case that's hard for whatever reason maybe you'd want to merge this as a temporary measure.

If I don't have an `.asdfrc` file then I get this error:
```
$ ruby -v
error: open /Users/jordan/.asdfrc: no such file or directory
```