### PR TITLE
Add readme instruction to make downloaded `reshim.sh` executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ and put it in `~/.asdf/bin/private` as `asdf-exec`
 wget https://github.com/danhper/asdf-exec/releases/download/v0.1/asdf-exec-linux-x64 -O ~/.asdf/bin/private/asdf-exec
 # for macos
 wget https://github.com/danhper/asdf-exec/releases/download/v0.1/asdf-exec-darwin-x64 -O ~/.asdf/bin/private/asdf-exec
+
+# for both:
+chmod +x ~/.asdf/bin/private/asdf-exec
 ```
 
 Then, patch asdf reshim command code and regenerate all shims.


### PR DESCRIPTION
Note: It would probably be better to just make this executable to begin with, but in case that's not possible for some reason, this adds a workaround in the readme.

Without this I get the following error:
```
$ ruby -v
/Users/jordan/.asdf/shims/ruby: line 4: /Users/jordan/.asdf/bin/private/asdf-exec: Permission denied
/Users/jordan/.asdf/shims/ruby: line 4: exec: /Users/jordan/.asdf/bin/private/asdf-exec: cannot execute: Undefined error: 0
```