### PR TITLE
Added environment variable to fix issue with aws cli

### DIFF
--- a/shim.go
+++ b/shim.go
@@ -158,7 +158,10 @@ func GetExecutablePath(executable Executable) (string, error) {
 		return exePath, nil
 	}
 
-	rawBinPaths, err := exec.Command("bash", listBinPath).Output()
+	bashCommand := exec.Command("bash", listBinPath)
+	bashCommand.Env = os.Environ()
+	bashCommand.Env = append(bashCommand.Env, fmt.Sprintf("ASDF_INSTALL_VERSION=%s", executable.PluginVersion))
+	rawBinPaths, err := bashCommand.Output()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION

This binary was not working for me to find the aws cli installed with asdf but the normal one did. 

[Here](https://github.com/MetricMike/asdf-awscli/blob/c645552054ad8a8bf3521cc37e7f44ea9dba1def/bin/list-bin-paths#L5-L8) you can see how they use the environment variable to detect the installed version. 

